### PR TITLE
TypeScript definitions

### DIFF
--- a/jquery.animate_from_to-1.0.d.ts
+++ b/jquery.animate_from_to-1.0.d.ts
@@ -1,0 +1,11 @@
+/// <reference path="node_modules/@types/jquery/index.d.ts" /> from @types/jquery@2 for JQuery & JQueryCssProperties
+interface JQueryAnimateFromToOptions {
+	callback?: () => void;
+	initial_css?: JQueryCssProperties;
+	pixels_per_second?: number;
+	square?: ""|"height"|"width";
+}
+
+declare interface JQuery {
+	animate_from_to: (targetElm: HTMLElement|string, options?: JQueryAnimateFromToOptions) => JQuery;
+}


### PR DESCRIPTION
Added a TypeScript definiton file, to enable the use of this addon from TypeScript.

Declares the function animate_from_to on the JQuery object,
with the parameters:
 * targetElm as string or HTMLElement
 * options as an object that can have callback, initial_css, pixels_per_second & square.

![screenshot from 2019-01-18 16-33-22](https://user-images.githubusercontent.com/866668/51396145-cb0c1600-1b3e-11e9-8c50-501e59fdb6b6.png)

